### PR TITLE
Handle missing logs directory and clean extension parsing

### DIFF
--- a/file_manager.sh
+++ b/file_manager.sh
@@ -13,18 +13,23 @@ fi
 
 TARGET_DIR="$1"
 EXT_FILTER="${2:-txt}"  # Default to txt if not provided
-LOG_FILE="logs/output.log"
-ERROR_FILE="logs/error.log"
+# Strip a leading dot from the extension, if present
+EXT_FILTER="${EXT_FILTER#.}"
+
+start_dir=$(pwd)
+
+LOG_DIR="$start_dir/logs"
+LOG_FILE="$LOG_DIR/output.log"
+ERROR_FILE="$LOG_DIR/error.log"
+
+# Create log directory if it doesn't exist
+mkdir -p "$LOG_DIR"
 
 # ========== 2. Logging Start ==========
 echo "========== File Manager Run ==========" > "$LOG_FILE"
 echo "Target Directory: $TARGET_DIR" >> "$LOG_FILE"
 echo "File Extension Filter: *.$EXT_FILTER" >> "$LOG_FILE"
 echo "Start Time: $(date)" >> "$LOG_FILE"
-
-
-# ========== 3. Save Current Directory ==========
-start_dir=$(pwd)
 
 
 # ========== 4. Change to Target Directory ==========

--- a/readme.md
+++ b/readme.md
@@ -20,3 +20,10 @@ This project is a simple Bash script that demonstrates:
 
 ```bash
 ./file_manager.sh <directory> [file_extension]
+```
+
+The script automatically creates a `logs/` directory and stores its standard
+output in `logs/output.log` and errors in `logs/error.log`. Provide the target
+directory and optional file extension (with or without the leading dot) to
+filter files.
+


### PR DESCRIPTION
## Summary
- Ensure file_manager.sh creates a logs directory and uses absolute paths
- Strip leading dots from provided extensions
- Document log behavior and usage in README

## Testing
- `./file_manager.sh scripts sh`


------
https://chatgpt.com/codex/tasks/task_e_68c1e29968008327a2f114f226fff84c